### PR TITLE
fix directory permissions following build

### DIFF
--- a/bin/init-idp.sh
+++ b/bin/init-idp.sh
@@ -11,6 +11,8 @@ rm -r ../conf/
 echo "Please complete the following for your IdP environment:"
 ./build.sh -Didp.target.dir=/opt/shibboleth-idp init gethostname askscope metadata-gen
 
+find /opt/shibboleth-idp/ -type d -exec chmod 750 {} \;
+
 mkdir -p /ext-mount/customized-shibboleth-idp/conf/
 
 # Copy the essential and routinely customized config to out Docker mount.


### PR DESCRIPTION
this resolves the issue regarding borked-up permissions in the `customized-shibboleth-idp` directory after running `init-idp.sh`